### PR TITLE
Create client-side shots gained tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# Shots-Gained
-App to Track Shots Gained
+# Shots Gained Tracker
+
+This project is a lightweight, client-side web app for logging golf shots and calculating strokes gained insights for each round you play.
+
+## Running locally
+
+Open `index.html` in your browser or serve the project from a simple static server:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000).
+
+## Features
+
+- Create, select, and delete rounds.
+- Capture shot-level data including lie, distance, expected strokes, and strokes to finish.
+- Automatic strokes gained calculation with per-round, per-hole, per-shot, and per-category summaries.
+- Edit or remove individual shots and clear entire rounds.
+- Export your data to JSON for safekeeping and import it on another device.
+
+All data stays in your browser via `localStorage` until you export it.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shots Gained Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Shots Gained Tracker</h1>
+      <p class="tagline">Log every shot and understand where you're gaining strokes.</p>
+    </header>
+
+    <main class="app">
+      <aside class="sidebar">
+        <section class="panel">
+          <h2>Rounds</h2>
+          <form id="round-form" class="form grid-form">
+            <div class="form-field">
+              <label for="roundName">Round name</label>
+              <input id="roundName" name="roundName" type="text" placeholder="Saturday skins" required />
+            </div>
+            <div class="form-field">
+              <label for="course">Course</label>
+              <input id="course" name="course" type="text" placeholder="Pebble Beach" />
+            </div>
+            <div class="form-field">
+              <label for="date">Date</label>
+              <input id="date" name="date" type="date" />
+            </div>
+            <div class="form-field full-width">
+              <label for="roundNotes">Notes</label>
+              <textarea id="roundNotes" name="roundNotes" rows="2" placeholder="Windy on the back nine"></textarea>
+            </div>
+            <button type="submit" class="primary">Create round</button>
+          </form>
+        </section>
+
+        <section class="panel">
+          <h3>Saved rounds</h3>
+          <ul id="round-list" class="round-list"></ul>
+          <div class="sidebar-actions">
+            <button id="delete-round" class="danger" disabled>Delete selected</button>
+            <button id="export-data" class="secondary">Export data</button>
+            <label class="import-button">
+              <input id="import-data" type="file" accept="application/json" hidden />
+              <span>Import data</span>
+            </label>
+          </div>
+        </section>
+      </aside>
+
+      <section class="content" aria-live="polite">
+        <div id="empty-state" class="empty-state">
+          <h2>No round selected</h2>
+          <p>Create a round or choose one from the list to start logging shots.</p>
+        </div>
+
+        <div id="round-view" class="round-view hidden">
+          <header class="round-header">
+            <div>
+              <h2 id="round-title"></h2>
+              <p id="round-meta" class="muted"></p>
+            </div>
+            <p id="round-notes" class="muted"></p>
+          </header>
+
+          <section class="panel">
+            <h3>Add a shot</h3>
+            <form id="shot-form" class="form grid-form">
+              <input type="hidden" id="shotId" name="shotId" />
+              <div class="form-field">
+                <label for="hole">Hole</label>
+                <input id="hole" name="hole" type="number" min="1" max="18" required />
+              </div>
+              <div class="form-field">
+                <label for="shotNumber">Shot #</label>
+                <input id="shotNumber" name="shotNumber" type="number" min="1" required />
+              </div>
+              <div class="form-field">
+                <label for="lie">Lie</label>
+                <select id="lie" name="lie" required>
+                  <option value="">Select</option>
+                  <option value="Tee">Tee</option>
+                  <option value="Fairway">Fairway</option>
+                  <option value="Rough">Rough</option>
+                  <option value="Sand">Sand</option>
+                  <option value="Recovery">Recovery</option>
+                  <option value="Green">Green</option>
+                </select>
+              </div>
+              <div class="form-field">
+                <label for="distance">Distance (yards)</label>
+                <input id="distance" name="distance" type="number" min="0" step="0.1" />
+              </div>
+              <div class="form-field">
+                <label for="expected">Expected strokes</label>
+                <input id="expected" name="expected" type="number" min="0" step="0.01" required />
+              </div>
+              <div class="form-field">
+                <label for="actual">Strokes to hole out</label>
+                <input id="actual" name="actual" type="number" min="0" step="0.01" required />
+              </div>
+              <div class="form-field full-width">
+                <label for="shotNotes">Notes</label>
+                <textarea id="shotNotes" name="shotNotes" rows="2" placeholder="Pulled into left rough"></textarea>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="primary" id="save-shot">Save shot</button>
+                <button type="button" class="secondary" id="cancel-edit" hidden>Cancel</button>
+              </div>
+            </form>
+            <p class="muted help-text">
+              Strokes gained = expected strokes to hole out from that position minus the strokes you actually took to finish the hole.
+            </p>
+          </section>
+
+          <section class="panel">
+            <div class="panel-header">
+              <h3>Round summary</h3>
+              <button id="clear-shots" class="secondary" type="button">Clear shots</button>
+            </div>
+            <div id="summary" class="summary-grid"></div>
+          </section>
+
+          <section class="panel">
+            <h3>Shots</h3>
+            <div class="table-container">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Hole</th>
+                    <th>Shot</th>
+                    <th>Lie</th>
+                    <th>Distance</th>
+                    <th>Expected</th>
+                    <th>Actual</th>
+                    <th>Gained</th>
+                    <th>Notes</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody id="shot-table"></tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        Data is stored locally in your browser. Export your rounds to back them up or move to another device.
+      </p>
+    </footer>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,442 @@
+const STORAGE_KEY = 'shots-gained-rounds';
+const CATEGORY_MAP = {
+  Tee: 'Tee shots',
+  Fairway: 'Approach',
+  Rough: 'Approach',
+  Sand: 'Short game',
+  Recovery: 'Short game',
+  Green: 'Putting',
+};
+
+let rounds = [];
+let selectedRoundId = null;
+let editingShotId = null;
+
+const roundListEl = document.getElementById('round-list');
+const roundForm = document.getElementById('round-form');
+const deleteRoundBtn = document.getElementById('delete-round');
+const exportBtn = document.getElementById('export-data');
+const importInput = document.getElementById('import-data');
+const emptyState = document.getElementById('empty-state');
+const roundView = document.getElementById('round-view');
+const roundTitle = document.getElementById('round-title');
+const roundMeta = document.getElementById('round-meta');
+const roundNotes = document.getElementById('round-notes');
+const summaryEl = document.getElementById('summary');
+const shotTable = document.getElementById('shot-table');
+const shotForm = document.getElementById('shot-form');
+const cancelEditBtn = document.getElementById('cancel-edit');
+const clearShotsBtn = document.getElementById('clear-shots');
+
+const shotIdInput = document.getElementById('shotId');
+const holeInput = document.getElementById('hole');
+const shotNumberInput = document.getElementById('shotNumber');
+const lieInput = document.getElementById('lie');
+const distanceInput = document.getElementById('distance');
+const expectedInput = document.getElementById('expected');
+const actualInput = document.getElementById('actual');
+const shotNotesInput = document.getElementById('shotNotes');
+const saveShotBtn = document.getElementById('save-shot');
+
+function loadRounds() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        rounds = parsed;
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load rounds from localStorage', error);
+  }
+}
+
+function persistRounds() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(rounds));
+  } catch (error) {
+    console.error('Failed to save rounds', error);
+  }
+}
+
+function createRound({ name, course, date, notes }) {
+  const round = {
+    id: `round-${Date.now()}`,
+    name,
+    course,
+    date,
+    notes,
+    shots: [],
+  };
+  rounds.unshift(round);
+  persistRounds();
+  setSelectedRound(round.id);
+  renderRoundList();
+}
+
+function deleteSelectedRound() {
+  if (!selectedRoundId) return;
+  const round = getSelectedRound();
+  const confirmed = confirm(`Delete \"${round.name}\" and all of its shots?`);
+  if (!confirmed) return;
+  rounds = rounds.filter((r) => r.id !== selectedRoundId);
+  persistRounds();
+  selectedRoundId = rounds[0]?.id ?? null;
+  renderRoundList();
+  updateRoundView();
+}
+
+function getSelectedRound() {
+  return rounds.find((round) => round.id === selectedRoundId) ?? null;
+}
+
+function setSelectedRound(id) {
+  selectedRoundId = id;
+  renderRoundList();
+  updateRoundView();
+}
+
+function renderRoundList() {
+  roundListEl.innerHTML = '';
+  if (!rounds.length) {
+    const emptyItem = document.createElement('li');
+    emptyItem.className = 'muted';
+    emptyItem.textContent = 'No rounds yet. Create one above.';
+    roundListEl.appendChild(emptyItem);
+    deleteRoundBtn.disabled = true;
+    return;
+  }
+
+  rounds.forEach((round) => {
+    const item = document.createElement('li');
+    const button = document.createElement('button');
+    button.textContent = round.name;
+
+    const meta = [];
+    if (round.course) meta.push(round.course);
+    if (round.date) meta.push(formatDate(round.date));
+    if (meta.length) {
+      const subtitle = document.createElement('div');
+      subtitle.className = 'muted';
+      subtitle.textContent = meta.join(' · ');
+      button.appendChild(document.createElement('br'));
+      button.appendChild(subtitle);
+    }
+
+    if (round.id === selectedRoundId) {
+      button.classList.add('active');
+    }
+
+    button.addEventListener('click', () => {
+      setSelectedRound(round.id);
+    });
+
+    item.appendChild(button);
+    roundListEl.appendChild(item);
+  });
+
+  deleteRoundBtn.disabled = !selectedRoundId;
+}
+
+function updateRoundView() {
+  const round = getSelectedRound();
+  if (!round) {
+    roundView.classList.add('hidden');
+    emptyState.classList.remove('hidden');
+    deleteRoundBtn.disabled = true;
+    return;
+  }
+
+  emptyState.classList.add('hidden');
+  roundView.classList.remove('hidden');
+  deleteRoundBtn.disabled = false;
+
+  roundTitle.textContent = round.name;
+  const metaParts = [];
+  if (round.course) metaParts.push(round.course);
+  if (round.date) metaParts.push(formatDate(round.date));
+  roundMeta.textContent = metaParts.join(' · ');
+  roundNotes.textContent = round.notes ?? '';
+  roundNotes.classList.toggle('hidden', !round.notes);
+
+  resetShotForm();
+  renderSummary(round);
+  renderShots(round);
+}
+
+function renderSummary(round) {
+  if (!round.shots.length) {
+    summaryEl.innerHTML = '<p class="muted">Add shots to see your strokes gained summary.</p>';
+    return;
+  }
+
+  const totals = {
+    overall: 0,
+    categories: {},
+    holes: new Set(),
+    shots: round.shots.length,
+  };
+
+  Object.values(CATEGORY_MAP).forEach((label) => {
+    totals.categories[label] = 0;
+  });
+
+  round.shots.forEach((shot) => {
+    const gained = calculateStrokesGained(shot);
+    totals.overall += gained;
+    const categoryLabel = CATEGORY_MAP[shot.lie] ?? 'Other';
+    totals.categories[categoryLabel] = (totals.categories[categoryLabel] ?? 0) + gained;
+    totals.holes.add(shot.hole);
+  });
+
+  const averagePerHole = totals.holes.size ? totals.overall / totals.holes.size : 0;
+  const averagePerShot = totals.shots ? totals.overall / totals.shots : 0;
+
+  const summaryCards = [
+    createSummaryCard('Total strokes gained', totals.overall),
+    createSummaryCard('Per hole', averagePerHole),
+    createSummaryCard('Per shot', averagePerShot),
+  ];
+
+  Object.entries(totals.categories).forEach(([label, value]) => {
+    summaryCards.push(createSummaryCard(label, value));
+  });
+
+  summaryEl.innerHTML = '';
+  summaryCards.forEach((card) => summaryEl.appendChild(card));
+}
+
+function createSummaryCard(label, value) {
+  const card = document.createElement('div');
+  card.className = 'summary-card';
+  const title = document.createElement('h4');
+  title.textContent = label;
+  const mainValue = document.createElement('div');
+  mainValue.className = 'value';
+  mainValue.textContent = formatNumber(value);
+  card.appendChild(title);
+  card.appendChild(mainValue);
+  return card;
+}
+
+function renderShots(round) {
+  const shots = [...round.shots].sort((a, b) => {
+    if (a.hole !== b.hole) return a.hole - b.hole;
+    return a.shotNumber - b.shotNumber;
+  });
+
+  shotTable.innerHTML = '';
+
+  if (!shots.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 9;
+    cell.className = 'muted';
+    cell.textContent = 'No shots logged yet.';
+    emptyRow.appendChild(cell);
+    shotTable.appendChild(emptyRow);
+    return;
+  }
+
+  shots.forEach((shot) => {
+    const row = document.createElement('tr');
+    row.dataset.id = shot.id;
+
+    row.innerHTML = `
+      <td>${shot.hole}</td>
+      <td>${shot.shotNumber}</td>
+      <td><span class="badge">${shot.lie}</span></td>
+      <td>${shot.distance !== null && shot.distance !== undefined ? `${formatNumber(shot.distance)} yds` : '—'}</td>
+      <td>${formatNumber(shot.expectedStrokes)}</td>
+      <td>${formatNumber(shot.actualStrokes)}</td>
+      <td>${formatNumber(calculateStrokesGained(shot))}</td>
+      <td>${shot.notes ? escapeHtml(shot.notes) : '—'}</td>
+      <td>
+        <div class="table-actions">
+          <button type="button" class="secondary" data-action="edit">Edit</button>
+          <button type="button" class="danger" data-action="delete">Delete</button>
+        </div>
+      </td>
+    `;
+
+    shotTable.appendChild(row);
+  });
+}
+
+function resetShotForm() {
+  shotForm.reset();
+  editingShotId = null;
+  cancelEditBtn.hidden = true;
+  saveShotBtn.textContent = 'Save shot';
+}
+
+function calculateStrokesGained(shot) {
+  return (Number(shot.expectedStrokes) || 0) - (Number(shot.actualStrokes) || 0);
+}
+
+function formatNumber(value) {
+  return Number(value).toFixed(2);
+}
+
+function formatDate(dateStr) {
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return dateStr;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function escapeHtml(value) {
+  const div = document.createElement('div');
+  div.textContent = value;
+  return div.innerHTML;
+}
+
+roundForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const formData = new FormData(roundForm);
+  const name = formData.get('roundName').trim();
+  if (!name) return;
+  createRound({
+    name,
+    course: formData.get('course').trim(),
+    date: formData.get('date'),
+    notes: formData.get('roundNotes').trim(),
+  });
+  roundForm.reset();
+});
+
+deleteRoundBtn.addEventListener('click', deleteSelectedRound);
+
+exportBtn.addEventListener('click', () => {
+  const data = JSON.stringify(rounds, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'shots-gained-rounds.json';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+});
+
+importInput.addEventListener('change', (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    try {
+      const imported = JSON.parse(e.target.result);
+      if (!Array.isArray(imported)) {
+        throw new Error('Invalid file format');
+      }
+      rounds = imported;
+      persistRounds();
+      selectedRoundId = rounds[0]?.id ?? null;
+      renderRoundList();
+      updateRoundView();
+      alert('Rounds imported successfully');
+    } catch (error) {
+      console.error(error);
+      alert('Could not import file. Please make sure it was exported from this app.');
+    }
+  };
+  reader.readAsText(file);
+  importInput.value = '';
+});
+
+shotForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const round = getSelectedRound();
+  if (!round) return;
+
+  const formData = new FormData(shotForm);
+  const shotData = {
+    id: editingShotId ?? `shot-${Date.now()}`,
+    hole: Number(formData.get('hole')),
+    shotNumber: Number(formData.get('shotNumber')),
+    lie: formData.get('lie'),
+    distance: formData.get('distance') ? Number(formData.get('distance')) : null,
+    expectedStrokes: Number(formData.get('expected')),
+    actualStrokes: Number(formData.get('actual')),
+    notes: formData.get('shotNotes').trim(),
+  };
+
+  if (!shotData.hole || !shotData.shotNumber || !shotData.lie) {
+    alert('Please fill in the required shot details.');
+    return;
+  }
+
+  const existingIndex = round.shots.findIndex((shot) => shot.id === shotData.id);
+  if (existingIndex >= 0) {
+    round.shots[existingIndex] = shotData;
+  } else {
+    round.shots.push(shotData);
+  }
+
+  persistRounds();
+  resetShotForm();
+  renderSummary(round);
+  renderShots(round);
+});
+
+cancelEditBtn.addEventListener('click', () => {
+  resetShotForm();
+});
+
+shotTable.addEventListener('click', (event) => {
+  const button = event.target.closest('button');
+  if (!button) return;
+  const row = button.closest('tr');
+  const shotId = row?.dataset.id;
+  if (!shotId) return;
+  const round = getSelectedRound();
+  if (!round) return;
+  const shot = round.shots.find((s) => s.id === shotId);
+  if (!shot) return;
+
+  const action = button.dataset.action;
+  if (action === 'delete') {
+    const confirmed = confirm('Delete this shot?');
+    if (!confirmed) return;
+    round.shots = round.shots.filter((s) => s.id !== shotId);
+    persistRounds();
+    renderSummary(round);
+    renderShots(round);
+    resetShotForm();
+  } else if (action === 'edit') {
+    editingShotId = shot.id;
+    shotIdInput.value = shot.id;
+    holeInput.value = shot.hole;
+    shotNumberInput.value = shot.shotNumber;
+    lieInput.value = shot.lie;
+    distanceInput.value = shot.distance ?? '';
+    expectedInput.value = shot.expectedStrokes;
+    actualInput.value = shot.actualStrokes;
+    shotNotesInput.value = shot.notes ?? '';
+    cancelEditBtn.hidden = false;
+    saveShotBtn.textContent = 'Update shot';
+  }
+});
+
+clearShotsBtn.addEventListener('click', () => {
+  const round = getSelectedRound();
+  if (!round || !round.shots.length) return;
+  const confirmed = confirm('Remove all shots from this round?');
+  if (!confirmed) return;
+  round.shots = [];
+  persistRounds();
+  renderSummary(round);
+  renderShots(round);
+  resetShotForm();
+});
+
+loadRounds();
+if (rounds.length) {
+  selectedRoundId = rounds[0].id;
+  renderRoundList();
+  updateRoundView();
+} else {
+  renderRoundList();
+  updateRoundView();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,353 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7fb;
+  --panel-bg: #ffffff;
+  --border: #d9dce5;
+  --accent: #1d4ed8;
+  --accent-soft: rgba(29, 78, 216, 0.1);
+  --danger: #dc2626;
+  --text: #0f172a;
+  --muted: #475569;
+  --shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 2rem clamp(1.5rem, 5vw, 4rem);
+  background: linear-gradient(120deg, #1d4ed8, #6366f1);
+  color: white;
+  box-shadow: var(--shadow);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  font-weight: 500;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 5vw, 3rem);
+  flex: 1;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.panel h2,
+.panel h3 {
+  margin-top: 0;
+}
+
+.round-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.round-list button {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: white;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.1s ease;
+}
+
+.round-list button:hover {
+  border-color: var(--accent);
+}
+
+.round-list button.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid-form {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font: inherit;
+  background: white;
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+button {
+  font: inherit;
+  border-radius: 999px;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: var(--accent);
+  color: white;
+}
+
+button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text);
+}
+
+button.danger {
+  background: var(--danger);
+  color: white;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.15);
+}
+
+.sidebar-actions {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.import-button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px dashed var(--border);
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.import-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: var(--panel-bg);
+  border-radius: 16px;
+  border: 1px dashed var(--border);
+  color: var(--muted);
+}
+
+.round-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.round-header h2 {
+  margin: 0;
+}
+
+.round-header p {
+  margin: 0.2rem 0 0;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.help-text {
+  margin-top: -0.5rem;
+  font-size: 0.9rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  border-radius: 14px;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.1), rgba(59, 130, 246, 0.1));
+}
+
+.summary-card h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.summary-card .value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-top: 0.5rem;
+}
+
+.summary-card .sub-value {
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+thead {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+tbody td {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+tbody tr:hover {
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+  font-size: 0.85rem;
+  background: rgba(29, 78, 216, 0.12);
+  color: var(--accent);
+}
+
+.hidden {
+  display: none;
+}
+
+.app-footer {
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: 2;
+  }
+
+  .content {
+    order: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    text-align: center;
+  }
+
+  .round-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive single-page interface for creating and managing golf rounds
- implement shot logging with strokes gained calculations, editing, and import/export persistence
- refresh documentation with setup instructions and feature overview

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e5e912bb38832fb03adf79bfd9becb